### PR TITLE
feat: set ajv as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "decimal.js": "^9.0.1"
   },
   "peerDependencies":{
-    "ajv": "6.x",
-  }
+    "ajv": "6.x"
+  },
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-jest": "^22.1.0",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
   "author": "bitebit",
   "license": "MIT",
   "dependencies": {
-    "ajv": "^6.1.1",
     "decimal.js": "^9.0.1"
   },
+  "peerDependencies":{
+    "ajv": "6.x",
+  }
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-jest": "^22.1.0",


### PR DESCRIPTION
I think that will be good to set ajv as peerDependency this way you will be able to maintain the library without update ajv