### PR TITLE
fix typings

### DIFF
--- a/lib/ajv-oai.d.ts
+++ b/lib/ajv-oai.d.ts
@@ -1,4 +1,4 @@
-import ajv from 'ajv';
+import * as ajv from 'ajv';
 
 declare var ajvOAI: {
   new (options?: ajv.Options & { metaSchema?: string }): ajv.Ajv;


### PR DESCRIPTION
The current way of importing `ajv` is supported only when `enableEsInteropt` is true — something most of the TypeScript projects do not do.